### PR TITLE
Python 3 Compatibilty -- little change

### DIFF
--- a/CmpCalib_matplotlib.py
+++ b/CmpCalib_matplotlib.py
@@ -34,9 +34,9 @@ class Calibration:
      file=open(self.path,'r')		
      for row in file :
          if re.match('\s\d', row) :
-            self.e_radiaux.append(map(float,row.split()))
+            self.e_radiaux.append(list(map(float,row.split())))
          elif re.match('\d', row):
-             self.e_plani.append(map(float,row.split()))	
+             self.e_plani.append(list(map(float,row.split())))	
      return
            
  def set_path(self,path):


### PR DESCRIPTION
@guihh thank you for that helpful Calib Comparing Tool!

I made a minor change to work with python 3 (using myself 3.8.3)

self.e_plani was containing a map object which could not be indexed by def set_e_plani_max(self)

Wrapped with list to fix.

all the best